### PR TITLE
Refactor use of custom transformers

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,7 +14,7 @@ The GitHub Actions Importer IssueOps repository demonstrates the functionality n
 
 Complete the following steps:
 
-1. Create a new repository using this repository as the template by clicking [here](https://github.com/actions/importer-issue-ops/generate). 
+1. Create a new repository using this repository as the template by clicking [here](https://github.com/actions/importer-issue-ops/generate).
 2. Create the following labels in this new repository: `jenkins`, `azure-devops`, `circle-ci`, `gitlab`, `travis-ci`, and `actions-importer-running`.
 3. Add the repository secrets described below that are relevant to the CI/CD providers being migrated:
 
@@ -94,6 +94,32 @@ Optionally, the following environment variables can be set:
 ## Pipeline migration
 
 Once configured, pipelines can be migrated to GitHub Actions by opening an issue with the relevant issue template and following the instructions.
+
+### Custom transformers
+
+See [./transformers/README.md](./transformers/README.md) for details on using custom transformers for `dry-run` and `migrate` commands.
+
+Custom transformers can be used to customize the behavior of Actions Importer to meet your specific use-case. Custom transformers can be used to:
+
+- Convert items that are not automatically converted.
+- Convert items that were automatically converted using different actions.
+- Convert environment variable values differently.
+- Convert references to runners to use a different runner name in Actions.
+
+Custom transformers must be defined in a file with the `.rb` file extension within a directory named `transformers` in your IssueOps repository. Alternatively, you can provide specific custom transformers to be used by appending the `--custom-transformers` option in the issue comment used to trigger Actions Importer. For example:
+
+```
+/migrate ... --custom-transformers my-transformers.rb
+```
+
+You can learn more about authoring custom transformers by completing the self-guided learning exercises below:
+
+- Custom transformers for Azure DevOps pipelines [exercise](https://github.com/actions/importer-labs/blob/main/azure_devops/5-custom-transformers.md)
+- Custom transformers for CircleCI pipelines [exercise](https://github.com/actions/importer-labs/blob/main/circle_ci/5-custom-transformers.md)
+- Custom transformers for GitLab pipelines [exercise](https://github.com/actions/importer-labs/blob/main/gitlab/5-custom-transformers.md)
+- Custom transformers for Jenkins pipelines [exercise](https://github.com/actions/importer-labs/blob/main/jenkins/5-custom-transformers.md)
+- Custom transformers for Travis CI pipelines [exercise](https://github.com/actions/importer-labs/blob/main/travis/5-custom-transformers.md)
+
 
 ## Privacy statement
 

--- a/lib/models/arguments.rb
+++ b/lib/models/arguments.rb
@@ -7,15 +7,22 @@ class Arguments
 
   def initialize(provider, command, issue_content)
     @args = argument_class(provider, command, issue_content)
+    @custom_transformers = custom_transformers(command)
   end
 
   def argument_class(provider, command, issue_content)
     provider.module.const_get(command.classify).new(issue_content, command)
   end
 
+  def custom_transformers(command)
+    command.options&.dig("custom-transformers")&.split(" ") || Dir.glob("transformers/**/*.rb")
+  end
+
   def to_output
     arguments = @args.to_a
     return if arguments.blank?
+
+    arguments.concat(["--custom-transformers", *@custom_transformers]) if @custom_transformers.length.positive?
 
     set_output(
       "args",


### PR DESCRIPTION
## Description

This builds upon @collinmcneese 's greatness in #1 to add support for passing custom transformers. This applies the logic in a slightly different location so that all commands present and future support the arguments.