### PR TITLE
adds workflow for on-deploy steps from template

### DIFF
--- a/.github/workflows/template-deploy.yml
+++ b/.github/workflows/template-deploy.yml
@@ -1,0 +1,58 @@
+# This workflow contains steps which execute when template is converted to a repository
+
+name: template-deploy
+
+on:
+  create:
+    ref: main
+    ref_type: branch
+
+permissions:
+  contents: write
+  issues: write
+
+jobs:
+  # Add issue labels expected by the repository
+  add-repo-labels:
+    if: ${{ !github.event.repository.is_template }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            let labels = [
+              {
+                name: 'jenkins',
+                color: '00FFFF',
+              },
+              {
+                name: 'azure-devops',
+                color: '00FFFF',
+              },
+              {
+                name: 'circle-ci',
+                color: '00FFFF',
+              },
+              {
+                name: 'gitlab',
+                color: '00FFFF',
+              },
+              {
+                name: 'travis-ci',
+                color: '00FFFF',
+              },
+              {
+                name: 'actions-importer-running',
+                color: '00FFFF',
+              }
+            ];
+
+            labels.forEach( (label) => {
+              github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label.name,
+                color: label.color,
+                description: 'Label used by Issue Ops workflow.'
+              });
+            });

--- a/.github/workflows/template-deploy.yml
+++ b/.github/workflows/template-deploy.yml
@@ -21,38 +21,20 @@ jobs:
         with:
           script: |
             let labels = [
-              {
-                name: 'jenkins',
-                color: '00FFFF',
-              },
-              {
-                name: 'azure-devops',
-                color: '00FFFF',
-              },
-              {
-                name: 'circle-ci',
-                color: '00FFFF',
-              },
-              {
-                name: 'gitlab',
-                color: '00FFFF',
-              },
-              {
-                name: 'travis-ci',
-                color: '00FFFF',
-              },
-              {
-                name: 'actions-importer-running',
-                color: '00FFFF',
-              }
+              'jenkins',
+              'azure-devops',
+              'circle-ci',
+              'gitlab',
+              'travis-ci',
+              'actions-importer-running'
             ];
 
             labels.forEach( (label) => {
               github.rest.issues.createLabel({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                name: label.name,
-                color: label.color,
+                name: label,
+                color: '00FFFF',
                 description: 'Label used by Issue Ops workflow.'
               });
             });

--- a/Readme.md
+++ b/Readme.md
@@ -15,7 +15,7 @@ The GitHub Actions Importer IssueOps repository demonstrates the functionality n
 Complete the following steps:
 
 1. Create a new repository using this repository as the template by clicking [here](https://github.com/actions/importer-issue-ops/generate).
-2. Create the following labels in this new repository: `jenkins`, `azure-devops`, `circle-ci`, `gitlab`, `travis-ci`, and `actions-importer-running`.  **Note**: This step should typically automatically complete upon repo creation from this template using the [template-deploy.yml](./github/../.github/workflows/template-deploy.yml) workflow but will need to be performed manually if this action fails or is unable to run at deploy time.
+2. Create the following labels in this new repository, if they are not already present: `jenkins`, `azure-devops`, `circle-ci`, `gitlab`, `travis-ci`, and `actions-importer-running`.
 3. Add the repository secrets described below that are relevant to the CI/CD providers being migrated:
 
 ### All CI/CD providers

--- a/Readme.md
+++ b/Readme.md
@@ -14,8 +14,8 @@ The GitHub Actions Importer IssueOps repository demonstrates the functionality n
 
 Complete the following steps:
 
-1. Create a new repository using this repository as the template by clicking [here](https://github.com/actions/importer-issue-ops/generate). 
-2. Create the following labels in this new repository: `jenkins`, `azure-devops`, `circle-ci`, `gitlab`, `travis-ci`, and `actions-importer-running`.
+1. Create a new repository using this repository as the template by clicking [here](https://github.com/actions/importer-issue-ops/generate).
+2. Create the following labels in this new repository: `jenkins`, `azure-devops`, `circle-ci`, `gitlab`, `travis-ci`, and `actions-importer-running`.  **Note**: This step should typically automatically complete upon repo creation from this template using the [template-deploy.yml](./github/../.github/workflows/template-deploy.yml) workflow but will need to be performed manually if this action fails or is unable to run at deploy time.
 3. Add the repository secrets described below that are relevant to the CI/CD providers being migrated:
 
 ### All CI/CD providers


### PR DESCRIPTION
# Description

Adds a GitHub Action workflow which triggers when a repository is created from this template to automatically create labels which are used by this repository, preventing users from having to manually create issue labels.


Signed-off-by: CollinM <collinmcneese@github.com>