### PR TITLE
Adds doc notes for supporting GHES and self-hosted runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   ruby_version: 2.7.1
-  # When using Self-Hosted Runner configurations, ImageOs must be populated to match the OS of the runner
+  # ImageOs must be configured to match the OS of the runner when using self-hosted runners.
   # ImageOS: ubuntu22
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
 
 env:
   ruby_version: 2.7.1
+  # When using Self-Hosted Runner configurations, ImageOs must be populated to match the OS of the runner
+  # ImageOS: ubuntu22
 
 jobs:
   unit-test:

--- a/.github/workflows/issue_ops.yml
+++ b/.github/workflows/issue_ops.yml
@@ -45,6 +45,9 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7.1
+        # When using Self-Hosted Runner configurations, ImageOs must be populated to match the OS of the runner
+        # env:
+        #     ImageOS: ubuntu22
       - name: Install dependencies
         run: bundle install --without development
       - name: Prepare arguments
@@ -150,15 +153,15 @@ jobs:
                 "</details>",
                 ""
               ]
-              
+
               for (const element of data) {
                 currentLength += element.length;
               }
-              
+
               if (currentLength > MAX_LENGTH){
                 break
               }
-              
+
               workflows.push(...data)
             }
 
@@ -232,7 +235,7 @@ jobs:
             <details>
               <summary>Logs :point_down:</summary>
 
-              \`\`\` 
+              \`\`\`
               ${logData.substring(0, Math.min(logData.length, MAX_LENGTH))}
               \`\`\`
             </details>

--- a/.github/workflows/issue_ops.yml
+++ b/.github/workflows/issue_ops.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7.1
-        # When using Self-Hosted Runner configurations, ImageOs must be populated to match the OS of the runner
+        # ImageOs must be configured to match the OS of the runner when using self-hosted runners.
         # env:
         #     ImageOS: ubuntu22
       - name: Install dependencies

--- a/Readme.md
+++ b/Readme.md
@@ -106,7 +106,7 @@ Custom transformers can be used to customize the behavior of Actions Importer to
 
 Custom transformers must be defined in a file with the `.rb` file extension within a directory named `transformers` in your IssueOps repository. Alternatively, you can provide specific custom transformers to be used by appending the `--custom-transformers` option in the issue comment used to trigger Actions Importer. For example:
 
-```
+```sh
 /migrate ... --custom-transformers my-transformers.rb
 ```
 
@@ -118,6 +118,13 @@ You can learn more about authoring custom transformers by completing the self-gu
 - Custom transformers for Jenkins pipelines [exercise](https://github.com/actions/importer-labs/blob/main/jenkins/5-custom-transformers.md)
 - Custom transformers for Travis CI pipelines [exercise](https://github.com/actions/importer-labs/blob/main/travis/5-custom-transformers.md)
 
+## GitHub Enterprise Server and Self-Hosted Runner Support
+
+This template can be used with GitHub Enterprise Server deployments or with Self-Hosted runners with additional considerations.
+
+1. See `Using self-hosted runners` details for action [ruby/setup-ruby](https://github.com/ruby/setup-ruby) to verify supported runner OS types and configuration prerequisites.
+2. Labels for `runs-on:` for [workflow files](.github/workflows/) must be updated to match an available label for Self-Hosted Runners
+3. For GitHub Enterprise Server deployments, this repository should be published and [converted to a template repository](https://docs.github.com/en/enterprise-server/repositories/creating-and-managing-repositories/creating-a-template-repository).
 
 ## Privacy statement
 

--- a/Readme.md
+++ b/Readme.md
@@ -118,13 +118,13 @@ You can learn more about authoring custom transformers by completing the self-gu
 - Custom transformers for Jenkins pipelines [exercise](https://github.com/actions/importer-labs/blob/main/jenkins/5-custom-transformers.md)
 - Custom transformers for Travis CI pipelines [exercise](https://github.com/actions/importer-labs/blob/main/travis/5-custom-transformers.md)
 
-## GitHub Enterprise Server and Self-Hosted Runner Support
+## Configuring IssueOps with GitHub Enterprise Server and self-hosted runners
 
-This template can be used with GitHub Enterprise Server deployments or with Self-Hosted runners with additional considerations.
+This template can be configured to be used with GitHub Enterprise Server deployments and self-hosted runners by:
 
-1. See `Using self-hosted runners` details for action [ruby/setup-ruby](https://github.com/ruby/setup-ruby) to verify supported runner OS types and configuration prerequisites.
-2. Labels for `runs-on:` for [workflow files](.github/workflows/) must be updated to match an available label for Self-Hosted Runners
-3. For GitHub Enterprise Server deployments, this repository should be published and [converted to a template repository](https://docs.github.com/en/enterprise-server/repositories/creating-and-managing-repositories/creating-a-template-repository).
+1. Updating the [ruby/setup-ruby](https://github.com/ruby/setup-ruby) actions in [issue_ops.yml](./.github/workflows/issue_ops.yml) and [ci.yml](./.github/workflows/ci.yml) to ensure the action runs on the correct OS type.
+2. Updating the `runs-on:` statements in [ruby/setup-ruby](https://github.com/ruby/setup-ruby) actions in [issue_ops.yml](./.github/workflows/issue_ops.yml) to dictate the appropriate label(s) for your self-hosted runner.
+3. For GitHub Enterprise Server deployments, this repository should be published and [converted to a template repository](https://docs.github.com/en/enterprise-server/repositories/creating-and-managing-repositories/creating-a-template-repository) in your GHES deployment.
 
 ## Privacy statement
 


### PR DESCRIPTION
Signed-off-by: Collin McNeese <collinmcneese@github.com>

This template repository works on GHES or Self-Hosted runners as well but there are additional considerations for runner configuration tied to the `ruby/setup-ruby` action.  Update of docs to reflect steps to be taken to support this -- links to the `ruby/setup-ruby` action docs directly for up-to-date support notes.
