### PR TITLE
Further command injection mitigation

### DIFF
--- a/.github/workflows/issue_ops.yml
+++ b/.github/workflows/issue_ops.yml
@@ -63,7 +63,7 @@ jobs:
           COMMENT_BODY: ${{ github.event.comment.body }}
           LABELS: ${{ toJSON(github.event.issue.labels.*.name) }}
         run: |
-          ./bin/parse_issue "${{ env.ISSUE_BODY }}" "${{ env.COMMENT_BODY }}" "${{ env.LABELS }}"
+          ./bin/parse_issue "$ISSUE_BODY" "$COMMENT_BODY" "$LABELS"
       - name: Validate arguments
         run: |
           if [ -z "${{ steps.prepare.outputs.provider }}" ]; then


### PR DESCRIPTION
`${{ env.FOO }}` is still expanded before script execution so it's safer to read values as environment variables within the script.