### PR TITLE
provider update for label parsing

### DIFF
--- a/lib/models/provider.rb
+++ b/lib/models/provider.rb
@@ -18,8 +18,7 @@ class Provider
   }.freeze
 
   def initialize(labels)
-    labels = labels.tr("\n", "").delete_prefix("[").delete_suffix("]").split(",").map(&:strip)
-    providers = labels.select { |label| PROVIDER_MAP.key?(label) }
+    providers = JSON.parse(labels).select { |label| PROVIDER_MAP.key?(label) }
 
     raise "One provider must be selected" if providers.empty?
     raise "Only one provider can be selected" unless providers.one?

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe Provider do
       let(:labels) do
         <<~LABELS
           [
-            jenkins,
-            azure-devops
+            "jenkins",
+            "azure-devops"
           ]
         LABELS
       end
@@ -33,7 +33,7 @@ RSpec.describe Provider do
       let(:labels) do
         <<~LABELS
           [
-            something-unsupported
+            "something-unsupported"
           ]
         LABELS
       end
@@ -45,7 +45,7 @@ RSpec.describe Provider do
       let(:labels) do
         <<~LABELS
           [
-            jenkins
+            "jenkins"
           ]
         LABELS
       end
@@ -59,7 +59,7 @@ RSpec.describe Provider do
     let(:labels) do
       <<~LABELS
         [
-          gitlab
+          "gitlab"
         ]
       LABELS
     end
@@ -73,7 +73,7 @@ RSpec.describe Provider do
     let(:labels) do
       <<~LABELS
         [
-          travis-ci
+          "travis-ci"
         ]
       LABELS
     end
@@ -87,7 +87,7 @@ RSpec.describe Provider do
     let(:labels) do
       <<~LABELS
         [
-          azure-devops
+          "azure-devops"
         ]
       LABELS
     end


### PR DESCRIPTION
Signed-off-by: Collin McNeese <collinmcneese@github.com>

Fixes an issue [introduced with a recent change](https://github.com/actions/importer-issue-ops/blame/7e77a1423051494bd17272bfea8206a5c177bd0c/.github/workflows/issue_ops.yml#L66) to the issue_ops.yml workflow which changed how label text was presented during parsing.

Since this arg is coming in as a JSON string from the workflow, updated to `JSON.parse` instead of adding yet more `tr` to remove extra `\"` which were introduced.

Issue symptom corrected by this -- `parse_issue.rb` is ends up sending extra `\"` characters to `provider.rb` (L40 in screenshot):
![image](https://user-images.githubusercontent.com/8185808/208948387-4bbbc0b2-6105-439c-8299-e29d1a4f2c6a.png)

