### PR TITLE
GitLab Updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/gitlab_ci.md
+++ b/.github/ISSUE_TEMPLATE/gitlab_ci.md
@@ -8,10 +8,9 @@ assignees: ""
 
 ## Inputs
 
-Provide the following required inputs:
+Provide the following **required** inputs:
 
-Namespace:
-_The GitLab namespace (or group) to migrate pipelines from._
+Namespace: **Replace this text with the GitLab namespace (or group) to migrate pipelines from.**
 
 ## Available commands
 

--- a/.github/workflows/issue_ops.yml
+++ b/.github/workflows/issue_ops.yml
@@ -19,6 +19,7 @@ env:
   TRAVIS_CI_ACCESS_TOKEN: ${{ secrets.travis_ci_access_token }}
   TRAVIS_CI_SOURCE_GITHUB_ACCESS_TOKEN: ${{ secrets.travis_ci_source_github_access_token }}
   GITLAB_ACCESS_TOKEN: ${{ secrets.gitlab_access_token }}
+  GITLAB_INSTANCE_URL: ${{ secrets.gitlab_instance_url || 'https://gitlab.com' }}
   CIRCLE_CI_ACCESS_TOKEN: ${{ secrets.circle_ci_access_token }}
   CIRCLE_CI_SOURCE_GITHUB_ACCESS_TOKEN: ${{ secrets.circle_ci_source_github_access_token }}
 


### PR DESCRIPTION
Signed-off-by: Collin McNeese collinmcneese@github.com

- Adds `GITLAB_INSTANCE_URL` to  issue_ops workflow as ENV from secret value -- without this present migrations only work from gitlab.com currently and cannot point to an instance URL.
- Updates GitLab issue template to be more specific on where `Namespace:` value should be placed to avoid confusion