### PR TITLE
Improve consistency of issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/azure_devops.md
+++ b/.github/ISSUE_TEMPLATE/azure_devops.md
@@ -10,11 +10,8 @@ assignees: ""
 
 Provide the following required inputs:
 
-Organization:
-_The Azure DevOps organization to migrate pipelines from._
-
-Project:
-_The Azure DevOps project to migrate pipelines from._
+Organization: _Replace this text with the Azure DevOps organization to migrate pipelines from._
+Project: _Replace this text with the Azure DevOps project to migrate pipelines from._
 
 ## Available commands
 

--- a/.github/ISSUE_TEMPLATE/circle_ci.md
+++ b/.github/ISSUE_TEMPLATE/circle_ci.md
@@ -10,7 +10,7 @@ assignees: ""
 
 Provide the following required inputs:
 
-Organization: _The CircleCI organization to migrate pipelines from._
+Organization: _Replace this text with the CircleCI organization to migrate pipelines from._
 
 ## Available commands
 

--- a/.github/ISSUE_TEMPLATE/gitlab_ci.md
+++ b/.github/ISSUE_TEMPLATE/gitlab_ci.md
@@ -10,7 +10,7 @@ assignees: ""
 
 Provide the following **required** inputs:
 
-Namespace: **Replace this text with the GitLab namespace (or group) to migrate pipelines from.**
+Namespace: _Replace this text with the GitLab namespace (or group) to migrate pipelines from._
 
 ## Available commands
 

--- a/.github/ISSUE_TEMPLATE/jenkins.md
+++ b/.github/ISSUE_TEMPLATE/jenkins.md
@@ -10,8 +10,7 @@ assignees: ""
 
 Provide the following optional inputs:
 
-Folders:
-_Include specific folders in an audit_
+Folders: _Include specific folders in an audit (delete if not applicable)_
 
 ## Available commands
 

--- a/.github/ISSUE_TEMPLATE/travis_ci.md
+++ b/.github/ISSUE_TEMPLATE/travis_ci.md
@@ -10,8 +10,7 @@ assignees: ""
 
 Provide the following required inputs:
 
-Organization:
-_The Travis CI organization to migrate pipelines from._
+Organization: _Replace this text  with the Travis CI organization to migrate pipelines from._
 
 ## Available commands
 


### PR DESCRIPTION
The content to be replaced is now on the same line for (Azure Devops, CircleCI and Jenkins). Since we expect values to be on the same line as the attributes, some templates were putting into on different line which might confuse users

Issue templates for different providers are more consistent with similar wording for the inputs