### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   unit-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.ruby_version }}
@@ -25,7 +25,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ env.ruby_version }}

--- a/.github/workflows/issue_ops.yml
+++ b/.github/workflows/issue_ops.yml
@@ -48,7 +48,7 @@ jobs:
               repo: context.repo.repo,
               labels: ['actions-importer-running']
             })
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.7.1

--- a/.github/workflows/issue_ops.yml
+++ b/.github/workflows/issue_ops.yml
@@ -90,7 +90,7 @@ jobs:
           path=$(ls output/log/*.log | head -1)
           filename=$(basename "$path")
           echo "LOG_FILE_PATH=$path" >> $GITHUB_ENV
-          echo "::set-output name=filename::$filename"
+          echo "filename=$filename" >> $GITHUB_OUTPUT
       - uses: actions/upload-artifact@v2
         if: always()
         with:
@@ -201,7 +201,7 @@ jobs:
         run: |
           pullRequest=$(grep "${{ env.pullRequestPattern }}" ${{ needs.execute-actions-importer.outputs.log-filename }} | sed -rn "s/^.*${{ env.pullRequestPattern }}'(.+)'.*$/\1/p")
           echo $pullRequest
-          echo ::set-output name=output::$pullRequest
+          echo "output=$pullRequest" >> $GITHUB_OUTPUT
         env:
           pullRequestPattern: "Pull request: "
       - uses: actions/github-script@v6

--- a/lib/concerns/output_writer.rb
+++ b/lib/concerns/output_writer.rb
@@ -4,6 +4,8 @@ module OutputWriter
   def set_output(name, value)
     return if value.nil?
 
-    puts "::set-output name=#{name}::#{value}"
+    File.open(ENV["GITHUB_OUTPUT"], "a") do |f|
+      f.puts "#{name}=#{value}"
+    end
   end
 end

--- a/spec/concerns/output_writer_spec.rb
+++ b/spec/concerns/output_writer_spec.rb
@@ -12,15 +12,16 @@ RSpec.describe OutputWriter do
   describe "#set_output" do
     let(:name) { "var_name" }
     let(:value) { "var_value" }
+    let(:output) { "#{name}=#{value}" }
 
     subject { test_class.set_output(name, value) }
 
-    it { expect { subject }.to output(/::set-output name=#{name}::#{value}/).to_stdout }
+    it { expect { subject }.to change { File.readlines(ENV["GITHUB_OUTPUT"], chomp: true).last }.to(/#{output}/) }
 
     context "when value is nil" do
       let(:value) { nil }
 
-      it { expect { subject }.not_to output(/::set-output name=#{name}::#{value}/).to_stdout }
+      it { expect { subject }.not_to change { File.read(ENV["GITHUB_OUTPUT"], chomp: true).last } }
     end
   end
 end

--- a/spec/models/command_spec.rb
+++ b/spec/models/command_spec.rb
@@ -104,6 +104,6 @@ RSpec.describe Command do
       COMMENT
     end
 
-    it { expect { subject }.to output(/::set-output name=command::audit/).to_stdout }
+    it { expect { subject }.to change { File.readlines(ENV["GITHUB_OUTPUT"], chomp: true).last }.to("command=audit") }
   end
 end

--- a/spec/models/provider_spec.rb
+++ b/spec/models/provider_spec.rb
@@ -52,6 +52,12 @@ RSpec.describe Provider do
 
       it { expect { subject }.not_to raise_error }
     end
+
+    context "when a provider is a quoted string" do
+      let(:labels) { "[ \"jenkins\" ]" }
+
+      it { expect { subject }.not_to raise_error }
+    end
   end
 
   describe "#cli_command" do
@@ -92,6 +98,6 @@ RSpec.describe Provider do
       LABELS
     end
 
-    it { expect { subject }.to output(/::set-output name=provider::azure-devops/).to_stdout }
+    it { expect { subject }.to change { File.readlines(ENV["GITHUB_OUTPUT"], chomp: true).last }.to("provider=azure-devops") }
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,7 @@
 require "bundler/setup"
 require "factory_bot"
 require "faker"
+require "fileutils"
 
 require_relative "./../cli"
 
@@ -25,5 +26,12 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     FactoryBot.find_definitions
+    Dir.mkdir("tmp") unless Dir.exist?("tmp")
+    FileUtils.touch "tmp/test.txt"
+    ENV["GITHUB_OUTPUT"] = "tmp/test.txt"
+  end
+
+  config.after(:suite) do
+    File.delete("tmp/test.txt")
   end
 end


### PR DESCRIPTION
## Description

Update `.github/workflows/issue_ops.yml` to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find . -name '*.yml' -o -name '*.yaml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
echo "::set-output name=filename::$filename"
```

```yml
echo ::set-output name=output::$pullRequest
```

**TO-BE**

```yml
echo "filename=$filename" >> $GITHUB_OUTPUT
```

```yml
echo "output=$pullRequest" >> $GITHUB_OUTPUT
```