### PR TITLE
Update Readme.md

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -32,6 +32,7 @@ See the [documentation](https://docs.github.com/en/repositories/managing-your-re
 The following secrets are required:
 
 - `GH_ACCESS_TOKEN`: GitHub personal access token to create pull requests (requires `repo` and `workflow` scopes).
+- `GHCR_PASSWORD`: GitHub personal access token to pull docker image. Or update the **Install GitHub Actions Importer** step in *issue_ops.yml* to use `GH_TOKEN: ${{ github.token }}`
 
 Optionally, the following secrets can be set:
 


### PR DESCRIPTION
**Install GitHub Actions Importer** step in *issue_ops.yml* was using `secrets.ghcr_password` which wasn't mentioned in README. 
The workflow was failing because of the absence of `ghcr_password` secret.