### PR TITLE
Support custom transformers for issue commands without arguments

### DIFF
--- a/lib/models/arguments.rb
+++ b/lib/models/arguments.rb
@@ -19,10 +19,10 @@ class Arguments
   end
 
   def to_output
-    arguments = @args.to_a
-    return if arguments.blank?
-
+    arguments = @args.to_a || []
     arguments.concat(["--custom-transformers", *@custom_transformers]) if @custom_transformers.length.positive?
+
+    return if arguments.blank?
 
     rng = Random.new
     variable_names = Set.new

--- a/lib/models/arguments.rb
+++ b/lib/models/arguments.rb
@@ -22,8 +22,6 @@ class Arguments
     arguments = @args.to_a || []
     arguments.concat(["--custom-transformers", *@custom_transformers]) if @custom_transformers.length.positive?
 
-    puts arguments.to_s
-
     return if arguments.blank?
 
     rng = Random.new

--- a/lib/models/arguments.rb
+++ b/lib/models/arguments.rb
@@ -22,6 +22,8 @@ class Arguments
     arguments = @args.to_a || []
     arguments.concat(["--custom-transformers", *@custom_transformers]) if @custom_transformers.length.positive?
 
+    puts arguments.to_s
+
     return if arguments.blank?
 
     rng = Random.new

--- a/transformers.rb
+++ b/transformers.rb
@@ -1,5 +1,0 @@
-# frozen_string_literal: true
-
-transform "jenkins.plugins.hipchat.HipChatNotifier", "org.jenkinsci.plugins.buildnamesetter.BuildNameSetter", "org.jenkinsci.plugins.builduser.BuildUser", "com.cloudbees.jenkins.GitHubSetCommitStatusBuilder", "org.jenkinsci.plugins.github.status.GitHubCommitStatusSetter", "org.jvnet.hudson.plugins.SbtPluginBuilder", "com.github.terma.jenkins.githubprcoveragestatus.CompareCoverageAction", "org.jenkinsci.plugins.github.status.GitHubCommitStatusSetter", "hudson.plugins.timestamper.TimestamperBuildWrapper", "hudson.plugins.ansicolor.AnsiColorBuildWrapper", "hudson.plugins.gradle.BuildScanBuildWrapper", "com.chikli.hudson.plugin.naginator.NaginatorPublisher", "org.jenkinsci.plugins.ParameterizedRemoteTrigger.RemoteBuildConfiguration", "com.cloudbees.jenkins.GitHubCommitNotifier", "hudson.plugins.descriptionsetter.DescriptionSetterPublisher" do
-  nil
-end

--- a/transformers.rb
+++ b/transformers.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+transform "jenkins.plugins.hipchat.HipChatNotifier", "org.jenkinsci.plugins.buildnamesetter.BuildNameSetter", "org.jenkinsci.plugins.builduser.BuildUser", "com.cloudbees.jenkins.GitHubSetCommitStatusBuilder", "org.jenkinsci.plugins.github.status.GitHubCommitStatusSetter", "org.jvnet.hudson.plugins.SbtPluginBuilder", "com.github.terma.jenkins.githubprcoveragestatus.CompareCoverageAction", "org.jenkinsci.plugins.github.status.GitHubCommitStatusSetter", "hudson.plugins.timestamper.TimestamperBuildWrapper", "hudson.plugins.ansicolor.AnsiColorBuildWrapper", "hudson.plugins.gradle.BuildScanBuildWrapper", "com.chikli.hudson.plugin.naginator.NaginatorPublisher", "org.jenkinsci.plugins.ParameterizedRemoteTrigger.RemoteBuildConfiguration", "com.cloudbees.jenkins.GitHubCommitNotifier", "hudson.plugins.descriptionsetter.DescriptionSetterPublisher" do
+  nil
+end


### PR DESCRIPTION
## Description

This addresses a bug where issue comments that didn't have arguments other than the `--custom-transformers` arg, would silently ignore the custom transformers. Now, the following commands will work as expected:

```bash
/audit --custom-transformers transformers.rb 
```
☝️ assuming that custom transformers are defined in a file `transformers.rb` at the root of the repo

```bash
/audit
```
☝️ assuming that custom transformers are defined in the `transformers/` directory of the repo