### PR TITLE
Address concerns with parsing option prefixes

### DIFF
--- a/lib/models/arguments.rb
+++ b/lib/models/arguments.rb
@@ -20,7 +20,7 @@ class Arguments
 
   def to_output
     arguments = @args.to_a || []
-    arguments.concat(["--custom-transformers", *@custom_transformers]) if @custom_transformers.length.positive?
+    arguments.push(["--custom-transformers", *@custom_transformers]) if @custom_transformers.length.positive?
 
     return if arguments.blank?
 
@@ -29,21 +29,27 @@ class Arguments
 
     set_output(
       "args",
-      arguments.map do |a|
-        value = a.include?(" ") ? a.inspect : a
+      arguments.map do |value|
+        unless value.is_a?(Array)
+          value = value.inspect if value.include?(" ")
+          
+          next value
+        end
 
-        unless value.start_with?("--")
+        value.map.with_index do |v, index|
+          v = v.inspect if v.include?(" ")
+
+          next v if index.zero?
+
           name = "variable_#{rng.rand(1000..9999)}"
           name = "variable_#{rng.rand(1000..9999)}" while variable_names.include?(name)
 
           variable_names.add(name)
 
-          set_environment(name, value)
+          set_environment(name, v)
 
-          value = "$#{name}"
+          "$#{name}"
         end
-
-        value
       end.join(" ")
     )
   end

--- a/lib/models/arguments.rb
+++ b/lib/models/arguments.rb
@@ -32,7 +32,7 @@ class Arguments
       arguments.map do |value|
         unless value.is_a?(Array)
           value = value.inspect if value.include?(" ")
-          
+
           next value
         end
 

--- a/lib/models/azure_devops/audit.rb
+++ b/lib/models/azure_devops/audit.rb
@@ -11,8 +11,8 @@ module AzureDevops
 
     def to_a
       args = []
-      args.concat(["--azure-devops-organization", @organization]) unless @organization.nil?
-      args.concat(["--azure-devops-project", @project]) unless @project.nil?
+      args.push(["--azure-devops-organization", @organization]) unless @organization.nil?
+      args.push(["--azure-devops-project", @project]) unless @project.nil?
 
       return args unless args.empty?
     end

--- a/lib/models/azure_devops/dry_run.rb
+++ b/lib/models/azure_devops/dry_run.rb
@@ -14,9 +14,9 @@ module AzureDevops
 
     def to_a
       args = [@pipeline_type]
-      args.concat(["--azure-devops-organization", @organization]) unless @organization.nil?
-      args.concat(["--azure-devops-project", @project]) unless @project.nil?
-      args.concat(["--pipeline-id", @pipeline_id]) unless @pipeline_id.nil?
+      args.push(["--azure-devops-organization", @organization]) unless @organization.nil?
+      args.push(["--azure-devops-project", @project]) unless @project.nil?
+      args.push(["--pipeline-id", @pipeline_id]) unless @pipeline_id.nil?
 
       return args unless args.empty?
     end

--- a/lib/models/azure_devops/migrate.rb
+++ b/lib/models/azure_devops/migrate.rb
@@ -15,10 +15,10 @@ module AzureDevops
 
     def to_a
       args = [@pipeline_type]
-      args.concat(["--azure-devops-organization", @organization]) unless @organization.nil?
-      args.concat(["--azure-devops-project", @project]) unless @project.nil?
-      args.concat(["--pipeline-id", @pipeline_id]) unless @pipeline_id.nil?
-      args.concat(["--target-url", @target_url]) unless @target_url.nil?
+      args.push(["--azure-devops-organization", @organization]) unless @organization.nil?
+      args.push(["--azure-devops-project", @project]) unless @project.nil?
+      args.push(["--pipeline-id", @pipeline_id]) unless @pipeline_id.nil?
+      args.push(["--target-url", @target_url]) unless @target_url.nil?
 
       return args unless args.empty?
     end

--- a/lib/models/circle_ci/audit.rb
+++ b/lib/models/circle_ci/audit.rb
@@ -11,7 +11,7 @@ module CircleCI
     def to_a
       return if @organization.nil?
 
-      ["--circle-ci-organization", @organization]
+      [["--circle-ci-organization", @organization]]
     end
   end
 end

--- a/lib/models/circle_ci/dry_run.rb
+++ b/lib/models/circle_ci/dry_run.rb
@@ -11,8 +11,8 @@ module CircleCI
 
     def to_a
       args = []
-      args.concat(["--circle-ci-organization", @organization]) unless @organization.nil?
-      args.concat(["--circle-ci-project", @project]) unless @project.nil?
+      args.push(["--circle-ci-organization", @organization]) unless @organization.nil?
+      args.push(["--circle-ci-project", @project]) unless @project.nil?
 
       return args unless args.empty?
     end

--- a/lib/models/circle_ci/migrate.rb
+++ b/lib/models/circle_ci/migrate.rb
@@ -12,9 +12,9 @@ module CircleCI
 
     def to_a
       args = []
-      args.concat(["--circle-ci-organization", @organization]) unless @organization.nil?
-      args.concat(["--circle-ci-project", @project]) unless @project.nil?
-      args.concat(["--target-url", @target_url]) unless @target_url.nil?
+      args.push(["--circle-ci-organization", @organization]) unless @organization.nil?
+      args.push(["--circle-ci-project", @project]) unless @project.nil?
+      args.push(["--target-url", @target_url]) unless @target_url.nil?
 
       return args unless args.empty?
     end

--- a/lib/models/gitlab_ci/audit.rb
+++ b/lib/models/gitlab_ci/audit.rb
@@ -11,7 +11,7 @@ module GitlabCI
     def to_a
       return if @namespace.nil?
 
-      ["--namespace", @namespace]
+      [["--namespace", @namespace]]
     end
   end
 end

--- a/lib/models/gitlab_ci/dry_run.rb
+++ b/lib/models/gitlab_ci/dry_run.rb
@@ -11,8 +11,8 @@ module GitlabCI
 
     def to_a
       args = []
-      args.concat(["--namespace", @namespace]) unless @namespace.nil?
-      args.concat(["--project", @project]) unless @project.nil?
+      args.push(["--namespace", @namespace]) unless @namespace.nil?
+      args.push(["--project", @project]) unless @project.nil?
 
       return args unless args.empty?
     end

--- a/lib/models/gitlab_ci/migrate.rb
+++ b/lib/models/gitlab_ci/migrate.rb
@@ -12,9 +12,9 @@ module GitlabCI
 
     def to_a
       args = []
-      args.concat(["--namespace", @namespace]) unless @namespace.nil?
-      args.concat(["--project", @project]) unless @project.nil?
-      args.concat(["--target-url", @target_url]) unless @target_url.nil?
+      args.push(["--namespace", @namespace]) unless @namespace.nil?
+      args.push(["--project", @project]) unless @project.nil?
+      args.push(["--target-url", @target_url]) unless @target_url.nil?
 
       return args unless args.empty?
     end

--- a/lib/models/jenkins/audit.rb
+++ b/lib/models/jenkins/audit.rb
@@ -11,7 +11,7 @@ module Jenkins
     def to_a
       return if @folders.nil?
 
-      ["--folders", @folders]
+      [["--folders", @folders]]
     end
   end
 end

--- a/lib/models/jenkins/dry_run.rb
+++ b/lib/models/jenkins/dry_run.rb
@@ -11,7 +11,7 @@ module Jenkins
     def to_a
       return if @source_url.nil?
 
-      ["--source-url", @source_url]
+      [["--source-url", @source_url]]
     end
   end
 end

--- a/lib/models/jenkins/migrate.rb
+++ b/lib/models/jenkins/migrate.rb
@@ -11,8 +11,8 @@ module Jenkins
 
     def to_a
       args = []
-      args.concat(["--source-url", @source_url]) unless @source_url.nil?
-      args.concat(["--target-url", @target_url]) unless @target_url.nil?
+      args.push(["--source-url", @source_url]) unless @source_url.nil?
+      args.push(["--target-url", @target_url]) unless @target_url.nil?
 
       return args unless args.empty?
     end

--- a/lib/models/travis_ci/audit.rb
+++ b/lib/models/travis_ci/audit.rb
@@ -11,7 +11,7 @@ module TravisCI
     def to_a
       return if @organization.nil?
 
-      ["--travis-ci-organization", @organization]
+      [["--travis-ci-organization", @organization]]
     end
   end
 end

--- a/lib/models/travis_ci/dry_run.rb
+++ b/lib/models/travis_ci/dry_run.rb
@@ -11,8 +11,8 @@ module TravisCI
 
     def to_a
       args = []
-      args.concat(["--travis-ci-organization", @organization]) unless @organization.nil?
-      args.concat(["--travis-ci-repository", @repository]) unless @repository.nil?
+      args.push(["--travis-ci-organization", @organization]) unless @organization.nil?
+      args.push(["--travis-ci-repository", @repository]) unless @repository.nil?
 
       return args unless args.empty?
     end

--- a/lib/models/travis_ci/migrate.rb
+++ b/lib/models/travis_ci/migrate.rb
@@ -12,9 +12,9 @@ module TravisCI
 
     def to_a
       args = []
-      args.concat(["--travis-ci-organization", @organization]) unless @organization.nil?
-      args.concat(["--travis-ci-repository", @repository]) unless @repository.nil?
-      args.concat(["--target-url", @target_url]) unless @target_url.nil?
+      args.push(["--travis-ci-organization", @organization]) unless @organization.nil?
+      args.push(["--travis-ci-repository", @repository]) unless @repository.nil?
+      args.push(["--target-url", @target_url]) unless @target_url.nil?
 
       return args unless args.empty?
     end

--- a/spec/models/arguments_spec.rb
+++ b/spec/models/arguments_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Arguments do
     end
 
     context "when the output is not nil" do
-      let(:output) { ["--option", "value"] }
+      let(:output) { [["--option", "value"]] }
 
       it "writes an output variable" do
         expect(arguments).to receive(:set_output).with("args", /--option \$variable_\d{4}/)
@@ -61,7 +61,7 @@ RSpec.describe Arguments do
     end
 
     context "when the output contains a space" do
-      let(:output) { ["--option", "some value"] }
+      let(:output) { [["--option", "some value"]] }
 
       it "writes an output variable" do
         expect(arguments).to receive(:set_output).with("args", /--option \$variable_\d{4}/)
@@ -71,7 +71,7 @@ RSpec.describe Arguments do
     end
 
     context "when there is a custom transformers option" do
-      let(:output) { ["--option", "value"] }
+      let(:output) { [["--option", "value"]] }
       let(:options) { { "custom-transformers" => "transformers/**/*.rb" } }
 
       it "writes an output variable" do
@@ -84,7 +84,7 @@ RSpec.describe Arguments do
     end
 
     context "when there are custom transformers in the repository" do
-      let(:output) { ["--option", "value"] }
+      let(:output) { [["--option", "value"]] }
       let(:files) { ["transformers/jenkins/transformers.rb", "transformers/all.rb"] }
 
       before do

--- a/spec/models/azure_devops/audit_spec.rb
+++ b/spec/models/azure_devops/audit_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe AzureDevops::Audit do
         ISSUE
       end
 
-      it { is_expected.to eq(["--azure-devops-organization", "my-organization"]) }
+      it { is_expected.to eq([["--azure-devops-organization", "my-organization"]]) }
     end
 
     context "when issue_content contains a project" do
@@ -36,7 +36,7 @@ RSpec.describe AzureDevops::Audit do
         ISSUE
       end
 
-      it { is_expected.to eq(["--azure-devops-organization", "my-organization", "--azure-devops-project", "my-project"]) }
+      it { is_expected.to eq([["--azure-devops-organization", "my-organization"], ["--azure-devops-project", "my-project"]]) }
     end
   end
 end

--- a/spec/models/azure_devops/dry_run_spec.rb
+++ b/spec/models/azure_devops/dry_run_spec.rb
@@ -16,13 +16,13 @@ RSpec.describe AzureDevops::DryRun do
     context "when the comment body does not contain a pipeline type" do
       let(:comment_body) { "/dry-run" }
 
-      it { is_expected.to eq(["pipeline", "--azure-devops-organization", "my-organization", "--azure-devops-project", "my-project"]) }
+      it { is_expected.to eq(["pipeline", ["--azure-devops-organization", "my-organization"], ["--azure-devops-project", "my-project"]]) }
     end
 
     context "when the comment body contains a pipeline id" do
       let(:comment_body) { "/dry-run --pipeline-id 42" }
 
-      it { is_expected.to eq(["pipeline", "--azure-devops-organization", "my-organization", "--azure-devops-project", "my-project", "--pipeline-id", "42"]) }
+      it { is_expected.to eq(["pipeline", ["--azure-devops-organization", "my-organization"], ["--azure-devops-project", "my-project"], ["--pipeline-id", "42"]]) }
     end
   end
 end

--- a/spec/models/azure_devops/migrate_spec.rb
+++ b/spec/models/azure_devops/migrate_spec.rb
@@ -16,13 +16,13 @@ RSpec.describe AzureDevops::Migrate do
     context "when the comment body does not contain a pipeline type" do
       let(:comment_body) { "/migrate" }
 
-      it { is_expected.to eq(["pipeline", "--azure-devops-organization", "my-organization", "--azure-devops-project", "my-project"]) }
+      it { is_expected.to eq(["pipeline", ["--azure-devops-organization", "my-organization"], ["--azure-devops-project", "my-project"]]) }
     end
 
     context "when the comment body contains a pipeline id" do
       let(:comment_body) { "/migrate --pipeline-id 42 --target-url https://github.com/org/repo" }
 
-      it { is_expected.to eq(["pipeline", "--azure-devops-organization", "my-organization", "--azure-devops-project", "my-project", "--pipeline-id", "42", "--target-url", "https://github.com/org/repo"]) }
+      it { is_expected.to eq(["pipeline", ["--azure-devops-organization", "my-organization"], ["--azure-devops-project", "my-project"], ["--pipeline-id", "42"], ["--target-url", "https://github.com/org/repo"]]) }
     end
   end
 end

--- a/spec/models/circle_ci/audit_spec.rb
+++ b/spec/models/circle_ci/audit_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe CircleCI::Audit do
         ISSUE
       end
 
-      it { is_expected.to eq(["--circle-ci-organization", "testing"]) }
+      it { is_expected.to eq([["--circle-ci-organization", "testing"]]) }
     end
   end
 end

--- a/spec/models/circle_ci/dry_run_spec.rb
+++ b/spec/models/circle_ci/dry_run_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe CircleCI::DryRun do
     context "when the comment body contains a project" do
       let(:comment_body) { "/dry-run --project repo" }
 
-      it { is_expected.to eq(["--circle-ci-organization", "testing", "--circle-ci-project", "repo"]) }
+      it { is_expected.to eq([["--circle-ci-organization", "testing"], ["--circle-ci-project", "repo"]]) }
     end
   end
 end

--- a/spec/models/circle_ci/migrate_spec.rb
+++ b/spec/models/circle_ci/migrate_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe CircleCI::Migrate do
     context "when the comment body contains a project" do
       let(:comment_body) { "/migrate --project repo --target-url https://github.com/org/repo" }
 
-      it { is_expected.to eq(["--circle-ci-organization", "testing", "--circle-ci-project", "repo", "--target-url", "https://github.com/org/repo"]) }
+      it { is_expected.to eq([["--circle-ci-organization", "testing"], ["--circle-ci-project", "repo"], ["--target-url", "https://github.com/org/repo"]]) }
     end
   end
 end

--- a/spec/models/gitlab_ci/audit_spec.rb
+++ b/spec/models/gitlab_ci/audit_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe GitlabCI::Audit do
         ISSUE
       end
 
-      it { is_expected.to eq(["--namespace", "testing"]) }
+      it { is_expected.to eq([["--namespace", "testing"]]) }
     end
   end
 end

--- a/spec/models/gitlab_ci/dry_run_spec.rb
+++ b/spec/models/gitlab_ci/dry_run_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe GitlabCI::DryRun do
     context "when the comment body contains a pipeline id" do
       let(:comment_body) { "/dry-run --project project" }
 
-      it { is_expected.to eq(["--namespace", "testing", "--project", "project"]) }
+      it { is_expected.to eq([["--namespace", "testing"], ["--project", "project"]]) }
     end
   end
 end

--- a/spec/models/gitlab_ci/migrate_spec.rb
+++ b/spec/models/gitlab_ci/migrate_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe GitlabCI::Migrate do
     context "when the comment body contains a pipeline id" do
       let(:comment_body) { "/migrate --project project --target-url https://github.com/org/repo" }
 
-      it { is_expected.to eq(["--namespace", "testing", "--project", "project", "--target-url", "https://github.com/org/repo"]) }
+      it { is_expected.to eq([["--namespace", "testing"], ["--project", "project"], ["--target-url", "https://github.com/org/repo"]]) }
     end
   end
 end

--- a/spec/models/jenkins/audit_spec.rb
+++ b/spec/models/jenkins/audit_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Jenkins::Audit do
         ISSUE
       end
 
-      it { is_expected.to eq(["--folders", "test, prod"]) }
+      it { is_expected.to eq([["--folders", "test, prod"]]) }
     end
   end
 end

--- a/spec/models/jenkins/dry_run_spec.rb
+++ b/spec/models/jenkins/dry_run_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Jenkins::DryRun do
     context "when the comment body contains a pipeline id" do
       let(:comment_body) { "/dry-run --source-url https://jenkins.company.com/job/pipeline" }
 
-      it { is_expected.to eq(["--source-url", "https://jenkins.company.com/job/pipeline"]) }
+      it { is_expected.to eq([["--source-url", "https://jenkins.company.com/job/pipeline"]]) }
     end
   end
 end

--- a/spec/models/jenkins/migrate_spec.rb
+++ b/spec/models/jenkins/migrate_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Jenkins::Migrate do
     context "when the comment body contains a pipeline id" do
       let(:comment_body) { "/migrate --source-url https://jenkins.company.com/job/pipeline --target-url https://github.com/org/repo" }
 
-      it { is_expected.to eq(["--source-url", "https://jenkins.company.com/job/pipeline", "--target-url", "https://github.com/org/repo"]) }
+      it { is_expected.to eq([["--source-url", "https://jenkins.company.com/job/pipeline"], ["--target-url", "https://github.com/org/repo"]]) }
     end
   end
 end

--- a/spec/models/travis_ci/audit_spec.rb
+++ b/spec/models/travis_ci/audit_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe TravisCI::Audit do
         ISSUE
       end
 
-      it { is_expected.to eq(["--travis-ci-organization", "testing"]) }
+      it { is_expected.to eq([["--travis-ci-organization", "testing"]]) }
     end
   end
 end

--- a/spec/models/travis_ci/dry_run_spec.rb
+++ b/spec/models/travis_ci/dry_run_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe TravisCI::DryRun do
     context "when the comment body contains a pipeline id" do
       let(:comment_body) { "/dry-run --repository repo" }
 
-      it { is_expected.to eq(["--travis-ci-organization", "testing", "--travis-ci-repository", "repo"]) }
+      it { is_expected.to eq([["--travis-ci-organization", "testing"], ["--travis-ci-repository", "repo"]]) }
     end
   end
 end

--- a/spec/models/travis_ci/migrate_spec.rb
+++ b/spec/models/travis_ci/migrate_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe TravisCI::Migrate do
     context "when the comment body contains a pipeline id" do
       let(:comment_body) { "/migrate --repository repo --target-url https://github.com/org/repo" }
 
-      it { is_expected.to eq(["--travis-ci-organization", "testing", "--travis-ci-repository", "repo", "--target-url", "https://github.com/org/repo"]) }
+      it { is_expected.to eq([["--travis-ci-organization", "testing"], ["--travis-ci-repository", "repo"], ["--target-url", "https://github.com/org/repo"]]) }
     end
   end
 end


### PR DESCRIPTION
This avoids conditionally escaping user input if it starts with `--`. This is done by grouping all key/value pairs for options into an array of its own, where the first value is non-user-input and is the key, and the value is user-input that is escaped into variables.