### PR TITLE
Update workflow and README to use GH_INSTANCE_URL instead of GITHUB_INSTEAD_URL

### DIFF
--- a/.github/workflows/issue_ops.yml
+++ b/.github/workflows/issue_ops.yml
@@ -13,7 +13,7 @@ defaults:
     shell: bash
 
 env:
-  GITHUB_INSTANCE_URL: ${{ secrets.GITHUB_INSTANCE_URL || 'https://github.com' }}
+  GITHUB_INSTANCE_URL: ${{ secrets.GH_INSTANCE_URL || 'https://github.com' }}
   GITHUB_ACCESS_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
   JENKINS_INSTANCE_URL: ${{ secrets.JENKINS_INSTANCE_URL }}
   JENKINS_USERNAME: ${{ secrets.jenkins_username }}

--- a/Readme.md
+++ b/Readme.md
@@ -35,7 +35,7 @@ The following secrets are required:
 
 Optionally, the following secrets can be set:
 
-- `GITHUB_INSTANCE_URL`: The base URL of your GitHub instance (only required if it is **not** <https://github.com>).
+- `GH_INSTANCE_URL`: The base URL of your GitHub instance (only required if it is **not** <https://github.com>).
 
 ### Azure DevOps
 


### PR DESCRIPTION
Apparently, GitHub isn't allowing to declaration of any repository variables/secrets with the `GITHUB_` prefix. We can update the workflow YAML without affecting the underlying functionality. 

![image](https://github.com/actions/importer-issue-ops/assets/107094461/76839a16-6922-4d27-bd11-02b5800a65ec)
