### PR TITLE
Fix issue comment character limitation

### DIFF
--- a/.github/workflows/issue_ops.yml
+++ b/.github/workflows/issue_ops.yml
@@ -36,6 +36,7 @@ jobs:
     outputs:
       command: ${{ steps.prepare.outputs.command }}
       log-filename: ${{ steps.logs.outputs.filename }}
+      output-url: ${{ steps.output.outputs.artifact-url }}
     steps:
       - name: Install GitHub Actions Importer
         run: |
@@ -85,6 +86,7 @@ jobs:
             ${{ steps.prepare.outputs.args }} \
             --output-dir output
       - uses: actions/upload-artifact@v4
+        id: output
         if: always()
         with:
           path: output/
@@ -174,6 +176,8 @@ jobs:
               }
 
               if (currentLength > MAX_LENGTH){
+                workflows.push(`... Too large post in issue comment.`)
+                workflows.push(`Download the full dry-run output [here](${{ needs.execute-actions-importer.outputs.output-url }})`)
                 break
               }
 
@@ -208,10 +212,10 @@ jobs:
           echo $pullRequest
           echo "output=$pullRequest" >> $GITHUB_OUTPUT
         env:
-          pullRequestPattern: "Pull request: "
+          pullRequestPattern: 'Pull request: '
       - uses: actions/github-script@v7
         env:
-          PULL_REQUEST_URL: "${{ steps.pull-request-url.outputs.output }}"
+          PULL_REQUEST_URL: '${{ steps.pull-request-url.outputs.output }}'
         with:
           script: |
             const body = `Migration was successful :sparkles:

--- a/.github/workflows/issue_ops.yml
+++ b/.github/workflows/issue_ops.yml
@@ -176,8 +176,8 @@ jobs:
               }
 
               if (currentLength > MAX_LENGTH){
-                workflows.push(`... Too large post in issue comment.`)
-                workflows.push(`Download the full dry-run output [here](${{ needs.execute-actions-importer.outputs.output-url }})`)
+                workflows.push(`... Dry-run outputs are too large to display in issue comment.`)
+                workflows.push(`Download the full output [here](${{ needs.execute-actions-importer.outputs.output-url }})`)
                 break
               }
 


### PR DESCRIPTION
When dry-run output's length is beyond `MAX_LENGTH` it breaks the for-loop, and post the styled YML file(s). The unprocessed YML file(s) will not display in the issue comment and mislead user.

This change proposed to display a message that the output is too big, and provide the artifact URL to download the output.